### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,6 @@
 name: Test Python Package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Jayson-Fong/tabularize/security/code-scanning/1](https://github.com/Jayson-Fong/tabularize/security/code-scanning/1)

The best way to fix the problem is to explicitly add a `permissions:` block with the minimum required scopes. For this workflow, all steps only need to read repository contents (primarily for checkout); they do not create or modify content, pull requests, or releases. Therefore, `contents: read` at the workflow root is sufficient. This block should be inserted directly after the workflow `name:` at the top of the workflow file, before the `on:` block. No changes to any steps or jobs are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to explicitly grant read-only access to repository contents, aligning with least-privilege practices.
  * No changes to workflow triggers, steps, or execution behavior; pipelines run exactly as before.
  * Improves security posture and transparency without impacting product functionality or release processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->